### PR TITLE
Make kubernetes scripts compatible with docker-compose (PoC) (Do not merge)

### DIFF
--- a/compose/cpp/Dockerfile
+++ b/compose/cpp/Dockerfile
@@ -127,8 +127,7 @@ WORKDIR /
 RUN python3 -m pip install --upgrade pip
 
 RUN mkdir -p /go_attack/src
-COPY ./kubernetes/ /go_attack/kubernetes
-COPY ./scripts/ /go_attack/scripts
+COPY ./scripts /go_attack/scripts
 COPY ./src/go_attack /go_attack/src/go_attack
 COPY ./setup.py /go_attack/setup.py
 COPY README.md /go_attack/README.md
@@ -138,12 +137,15 @@ RUN pip install -e /go_attack --root-user-action=ignore
 COPY /engines/KataGo-custom/cpp/evaluate_loop.sh /engines/KataGo-custom/cpp/evaluate_loop.sh
 RUN chmod +x /engines/KataGo-custom/cpp/evaluate_loop.sh
 
+# Debug target
 FROM runtime-deps as debug
 COPY --from=build-custom-debug /engines/KataGo-custom/cpp/katago /engines/KataGo-custom/cpp/katago
-COPY ./configs /go_attack/configs
+COPY ./configs/ /go_attack/configs
+COPY ./kubernetes/ /go_attack/kubernetes
 
+# Prod target
 FROM runtime-deps as prod
 COPY --from=build-raw /engines/KataGo-raw/cpp/katago /engines/KataGo-raw/cpp/katago
 COPY --from=build-custom /engines/KataGo-custom/cpp/katago /engines/KataGo-custom/cpp/katago
-
-COPY ./configs /go_attack/configs
+COPY ./configs/ /go_attack/configs
+COPY ./kubernetes/ /go_attack/kubernetes

--- a/compose/python/Dockerfile
+++ b/compose/python/Dockerfile
@@ -45,12 +45,6 @@ FROM python-deps as prod
 COPY ./engines/KataGo-raw/python /engines/KataGo-raw/python
 COPY ./engines/KataGo-custom/python /engines/KataGo-custom/python
 
-COPY ./configs/ /go_attack/configs
-COPY ./kubernetes/ /go_attack/kubernetes
-COPY ./scripts/ /go_attack/scripts
-COPY ./src/go_attack /go_attack/src/go_attack
-COPY ./setup.py /go_attack/setup.py
-
 # Make /engines/KataGo-* git repos to make scripts run nicely.
 # TODO: Make this less hacky...
 WORKDIR /engines/KataGo-raw
@@ -65,6 +59,14 @@ RUN git init . \
   && git config user.name dummy_name \
   && git config user.email dummy@email.com \
   && git commit -m "Dummy commit"
+
+# Copy over our files
+COPY ./scripts/ /go_attack/scripts
+COPY ./setup.py /go_attack/setup.py
+COPY ./src/go_attack/ /go_attack/src/go_attack
+
+COPY ./configs/ /go_attack/configs
+COPY ./kubernetes/ /go_attack/kubernetes
 
 # Reset working directory
 WORKDIR /

--- a/compose/victimplay-pred.env
+++ b/compose/victimplay-pred.env
@@ -1,5 +1,5 @@
 # All paths here are with respect to the host filesystem.
 
-HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b10-curr-cp127-init
+HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b15-curr-cp127-init
 HOST_MODEL_DIR=/nas/ucb/tony/go-attack/victim-models
 VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/b20c256x2-s5303129600-d1228401921

--- a/compose/victimplay-pred.env
+++ b/compose/victimplay-pred.env
@@ -1,5 +1,5 @@
 # All paths here are with respect to the host filesystem.
 
-HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b15-curr-cp127-init
+HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b20-curr-cp505-init
 HOST_MODEL_DIR=/nas/ucb/tony/go-attack/victim-models
-VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/b20c256x2-s5303129600-d1228401921
+VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/kata1-b40c256-s11840935168-d2898845681

--- a/compose/victimplay-pred.env
+++ b/compose/victimplay-pred.env
@@ -1,5 +1,5 @@
 # All paths here are with respect to the host filesystem.
 
-HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b10-curr
+HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b10-curr-cp127-init
 HOST_MODEL_DIR=/nas/ucb/tony/go-attack/victim-models
-VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/kata1-b40c256-s11840935168-d2898845681
+VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/b20c256x2-s5303129600-d1228401921

--- a/compose/victimplay-pred.env
+++ b/compose/victimplay-pred.env
@@ -1,0 +1,5 @@
+# All paths here are with respect to the host filesystem.
+
+HOST_OUTPUT_DIR=/nas/ucb/tony/go-attack/training/vpred/b10-curr
+HOST_MODEL_DIR=/nas/ucb/tony/go-attack/victim-models
+VICTIM_PRED_INIT_WEIGHTS_DIR=/nas/ucb/tony/go-attack/victim-models/kata1-b40c256-s11840935168-d2898845681

--- a/compose/victimplay-pred.yml
+++ b/compose/victimplay-pred.yml
@@ -1,0 +1,148 @@
+# KataGo victimplay training with predictor net.
+#
+# See https://stackoverflow.com/a/52641495/1337463 for documentation on how to
+# run commands with `sh -c`.
+#
+# Launch command (run from repo root):
+# docker-compose -f compose/victimplay-pred.yml --env-file compose/victimplay-pred.env up
+
+version: "3"
+
+services:
+  curriculum: &python-base
+    image: humancompatibleai/goattack:python
+    build:
+      context: ..
+      dockerfile: ./compose/python/Dockerfile
+    volumes:
+      - type: bind
+        source: ${HOST_OUTPUT_DIR}
+        target: /outputs
+      - type: bind
+        source: ${HOST_MODEL_DIR}
+        target: /models
+        read_only: true
+      - type: bind
+        source: ${VICTIM_PRED_INIT_WEIGHTS_DIR}
+        target: /vpred_init_weights
+        read_only: true
+    cap_add:
+      - SYS_PTRACE
+    command: ./go_attack/kubernetes/curriculum.sh /outputs /models
+
+  shuffle-and-export:
+    <<: *python-base
+    command: ./go_attack/kubernetes/shuffle-and-export.sh /outputs adv
+
+  shuffle-and-export-pred:
+    <<: *python-base
+    command: ./go_attack/kubernetes/shuffle-and-export.sh /outputs/predictor vpred
+
+  train:
+    <<: *python-base
+    command: ./go_attack/kubernetes/train.sh /outputs/
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["0"]
+
+  train-pred:
+    <<: *python-base
+    command: ./go_attack/kubernetes/train.sh /outputs/predictor /vpred_init_weights
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["1"]
+
+  # Base victimplay config. Each service runs on only a single gpu.
+  # This is to prevent a bug which sometimes brings the whole server down.
+  #
+  # We sleep for a bit since we need to wait for dependencies.
+  # In particular we need to wait for curriculum to move the active victim into
+  # the correct folder, and we need to wait for the train/shuffle scripts to
+  # load initial (warmstart) weights if they are specified.
+  victimplay-2: &victimplay
+    image: humancompatibleai/goattack:cpp
+    build:
+      context: ..
+      dockerfile: ./compose/cpp/Dockerfile
+      target: prod
+    volumes:
+      - type: bind
+        source: ${HOST_OUTPUT_DIR}
+        target: /outputs
+    cap_add:
+      - SYS_PTRACE
+    depends_on:
+      - curriculum
+      - train
+      - train-pred
+      - shuffle-and-export
+      - shuffle-and-export-pred
+    command: >
+      sh -c "
+        sleep 20 && ./go_attack/kubernetes/victimplay-predictor.sh /outputs
+      "
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["2"]
+
+  victimplay-3:
+    <<: *victimplay
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["3"]
+
+  victimplay-4:
+    <<: *victimplay
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["4"]
+
+  victimplay-5:
+    <<: *victimplay
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["5"]
+
+  victimplay-6:
+    <<: *victimplay
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["6"]
+
+  victimplay-7:
+    <<: *victimplay
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["7"]

--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -5,3 +5,7 @@ oppRootSymmetriesOverride1 = 1
 oppVisitsOverride1 = 1
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
+
+# Increase gpu load
+numGameThreads = 400
+nnMaxBatchSize = 512

--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -5,7 +5,3 @@ oppRootSymmetriesOverride1 = 1
 oppVisitsOverride1 = 1
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
-
-# Increase gpu load
-numGameThreads = 400
-nnMaxBatchSize = 512

--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -1,16 +1,11 @@
 # Must be combined with a config file from the compute/ folder to work
 @include emcts1/base.cfg
 
-# Haven't fully audited this codepath yet.
-# We turn off this feature to make the experiment more controlled.
-useAuxPolicyTarget = false
-
 oppRootSymmetriesOverride1 = 1
 oppVisitsOverride1 = 1
-maxVisits0 = 32 # increase this to make victim stronger
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
 
 # Increase gpu load
-numGameThreads = 1600
+numGameThreads = 400
 nnMaxBatchSize = 512

--- a/kubernetes/curriculum.sh
+++ b/kubernetes/curriculum.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-RUN_NAME="$1"
-VOLUME_NAME="$2"
+BASE_DIR="$1"
+MODEL_DIR="$2"
+mkdir -p "$BASE_DIR"/selfplay
 python /engines/KataGo-custom/python/curriculum.py \
-    -selfplay-dir=/"$VOLUME_NAME"/victimplay/"$RUN_NAME"/selfplay/ \
-    -input-models-dir=/"$VOLUME_NAME"/victims \
-    -output-models-dir=/"$VOLUME_NAME"/victimplay/"$RUN_NAME"/victims \
+    -selfplay-dir="$BASE_DIR"/selfplay \
+    -input-models-dir="$MODEL_DIR" \
+    -output-models-dir="$BASE_DIR"/victims \
     -config-json-file=/go_attack/configs/curriculum.json

--- a/kubernetes/shuffle-and-export.sh
+++ b/kubernetes/shuffle-and-export.sh
@@ -1,8 +1,21 @@
 #!/bin/bash -e
 cd /engines/KataGo-custom/python
-RUN_NAME="$1"
-DIRECTORY="$2"
-VOLUME_NAME="$3"
-mkdir -p /"$VOLUME_NAME"/victimplay/"$DIRECTORY"
-./selfplay/shuffle_and_export_loop.sh    "$RUN_NAME"    /"$VOLUME_NAME"/victimplay/"$DIRECTORY"    /tmp    16    256    0
+BASE_DIR="$1" # containing selfplay data and models and related directories
+NAMEPREFIX="$2" # Displayed to users when KataGo loads the model
+
+mkdir -p "$BASE_DIR"
+
+selfplay_cmd=(
+    ./selfplay/shuffle_and_export_loop.sh
+    "$NAMEPREFIX"
+    "$BASE_DIR"
+    /tmp # scratch space, ideally on fast local disk, unique to this loop
+    16   # nthreads
+    256  # batchsize
+    0    # whether to use gatekeeper
+)
+"${selfplay_cmd[@]}" # run command from array (https://stackoverflow.com/a/27196266/1337463)
+
+# shuffle_and_export_loop.sh disowns subprocesses and exits.
+# We sleep at the end so the container doesn't exit.
 sleep infinity

--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -16,7 +16,7 @@ train_cmd=(
     ./selfplay/train.sh
     "$BASE_DIR"
     t0          # Name to prefix models with, specific to this training daemon
-    b10c128     # Network size (if no initial weights specified)
+    b15c192     # Network size (if no initial weights specified)
     256         # Batch size
     main        # EXPORTMODE
     -disable-vtimeloss

--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -1,15 +1,26 @@
 #!/bin/bash -e
 cd /engines/KataGo-custom/python
-RUN_NAME="$1"
-VOLUME_NAME="$2"
-INITIAL_WEIGHTS="$3"
-if [ -z "$INITIAL_WEIGHTS" ]; then
+BASE_DIR="$1"
+INITIAL_WEIGHTS_DIR="$2"
+
+if [ -z "$INITIAL_WEIGHT_DIR" ]; then
     echo "No initial weights specified, using random weights"
 else
-    echo "Using initial weights: $INITIAL_WEIGHTS"
-    mkdir -p /"$VOLUME_NAME"/victimplay/"$RUN_NAME"/train/t0
-    cp -r /"$VOLUME_NAME"/victim-weights/"$INITIAL_WEIGHTS"/saved_model/model.config.json /"$VOLUME_NAME"/victimplay/"$RUN_NAME"/train/t0/model.config.json
-    cp -r /"$VOLUME_NAME"/victim-weights/"$INITIAL_WEIGHTS"/saved_model/variables /"$VOLUME_NAME"/victimplay/"$RUN_NAME"/train/t0/initial_weights
+    echo "Using initial weights: $INITIAL_WEIGHT_DIR"
+    mkdir -p "$BASE_DIR"/train/t0
+    cp -r "$INITIAL_WEIGHTS_DIR"/saved_model/model.config.json "$BASE_DIR"/train/t0/model.config.json
+    cp -r "$INITIAL_WEIGHTS_DIR"/saved_model/variables "$BASE_DIR"/train/t0/initial_weights
 fi
 
-./selfplay/train.sh    /"$VOLUME_NAME"/victimplay/"$RUN_NAME"    t0    b6c96    256    main    -disable-vtimeloss    -lr-scale 1.0    -max-train-bucket-per-new-data 4
+train_cmd=(
+    ./selfplay/train.sh
+    "$BASE_DIR"
+    t0          # Name to prefix models with, specific to this training daemon
+    b10c128     # Network size (if no initial weights specified)
+    256         # Batch size
+    main        # EXPORTMODE
+    -disable-vtimeloss
+    -lr-scale 1.0
+    -max-train-bucket-per-new-data 4
+)
+"${train_cmd[@]}" # run command from array (https://stackoverflow.com/a/27196266/1337463)

--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -16,7 +16,7 @@ train_cmd=(
     ./selfplay/train.sh
     "$BASE_DIR"
     t0          # Name to prefix models with, specific to this training daemon
-    b15c192     # Network size (if no initial weights specified)
+    b20c256     # Network size (if no initial weights specified)
     256         # Batch size
     main        # EXPORTMODE
     -disable-vtimeloss

--- a/kubernetes/victimplay-predictor.sh
+++ b/kubernetes/victimplay-predictor.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+BASE_DIR="$1"
+mkdir -p "$BASE_DIR"
+/engines/KataGo-custom/cpp/katago victimplay \
+    -output-dir "$BASE_DIR"/selfplay \
+    -models-dir "$BASE_DIR"/models \
+    -nn-victim-path "$BASE_DIR"/victims \
+    -victim-output-dir "$BASE_DIR"/predictor/selfplay \
+    -nn-predictor-path "$BASE_DIR"/predictor/models \
+    -config /go_attack/configs/active-experiment.cfg \
+    -config /go_attack/configs/compute/1gpu.cfg


### PR DESCRIPTION
This PR is a proof of concept for how we could get docker-compose to talk with the kubernetes scripts. It was used to kick off some victim-predictor runs on GAN and PPO. **This PR breaks the highest level kubernetes launch scripts.**

Most of the logic is inside the kubernetes scripts, with the compose.yml file just specifying some high level directory mounts + device assignments. The kubernetes scripts were changed in how their working directories are specified. I thought this change was a simplification, but @norabelrose would appreciate a second opinion here.

Finally, there are also some small changes to the Dockerfiles themselves just to optimize dependency copying order (we want the most frequently changed things copied last so we can use the Docker cache whenever possible).