### PR TITLE
configs: Fix board size as 19x19 for `match`

### DIFF
--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -14,3 +14,10 @@ maxVisits0 = 32 # increase this to make victim stronger
 # Increase gpu load
 numGameThreads = 1600
 nnMaxBatchSize = 512
+
+# Vary the board size during victimplay
+bSizes = 7,9,11,13,15,17,19,  8,10,12,14,16,18
+bSizeRelProbs = 1,4,3,10,7,9,35, 1,2,4,6,8,10
+# Taken from lightvector's analysis in https://lifein19x19.com/viewtopic.php?f=15&t=17750
+# Board size: 7,    8,    9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19
+komiByBSize = 8.5, 9.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5

--- a/configs/emcts1/components/board-sizes.cfg
+++ b/configs/emcts1/components/board-sizes.cfg
@@ -1,7 +1,7 @@
 # Which board sizes we play on.
 
-bSizes = 7,9,11,13,15,17,19,  8,10,12,14,16,18
-bSizeRelProbs = 1,4,3,10,7,9,35, 1,2,4,6,8,10
+bSizes = 19
+bSizeRelProbs = 100
 allowRectangleProb = 0.00
 
 maxMovesPerGame = 1600

--- a/configs/emcts1/components/komi-handicap.cfg
+++ b/configs/emcts1/components/komi-handicap.cfg
@@ -1,15 +1,10 @@
 # Parameters affecting komi and handicap.
 
-# We make komi a constant 6.5, which is the most common komi per
-# https://en.wikipedia.org/wiki/Komi_(Go)
-# komiMean = 6.5
 komiStdev = 0
 komiBigStdevProb = 0
 komiBigStdev = 0
 
-# Taken from lightvector's analysis in https://lifein19x19.com/viewtopic.php?f=15&t=17750
-# Board size: 7,    8,    9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19
-komiByBSize = 8.5, 9.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5
+komiByBSize = 6.5  # for 19x19 boards
 
 komiAuto = false
 fancyKomiVarying = false

--- a/configs/match-base.cfg
+++ b/configs/match-base.cfg
@@ -1,8 +1,6 @@
 # NOT MEANT TO BE USED DIRECTLY - include a compute/*.cfg file in addition to this one
 @include emcts1/base.cfg
 
-# Haven't fully audited this codepath yet.
-# We turn off this feature to make the experiment more controlled.
 useAuxPolicyTarget = true
 maxVisits0 = 32 # victim
 numGamesTotal = 100


### PR DESCRIPTION
Changes configs to make 19x19 boards the default. Varying board sizes are enabled only in `active-experiment.cfg`