### PR TITLE
`kubernetes/launch-job.sh`: Don't launch extra job if `EXTRA_VICTIMPLAY_GPUS == 0`

### DIFF
--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -97,8 +97,8 @@ ctl job run --container \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1
 
 EXTRA_VICTIMPLAY_GPUS=$((MAX_VICTIMPLAY_GPUS-MIN_VICTIMPLAY_GPUS))
-# shellcheck disable=SC2086
 if [ $EXTRA_VICTIMPLAY_GPUS -gt 0 ]; then
+  # shellcheck disable=SC2086
   ctl job run --container \
       "$CPP_IMAGE" \
       $VOLUME_FLAGS \

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -98,10 +98,12 @@ ctl job run --container \
 
 EXTRA_VICTIMPLAY_GPUS=$((MAX_VICTIMPLAY_GPUS-MIN_VICTIMPLAY_GPUS))
 # shellcheck disable=SC2086
-ctl job run --container \
-    "$CPP_IMAGE" \
-    $VOLUME_FLAGS \
-    --command "/go_attack/kubernetes/victimplay.sh $RUN_NAME $VOLUME_NAME" \
-    --gpu 1 \
-    --name go-training-"$1"-victimplay \
-    --replicas "${EXTRA_VICTIMPLAY_GPUS}"
+if [ $EXTRA_VICTIMPLAY_GPUS -gt 0 ]; then
+  ctl job run --container \
+      "$CPP_IMAGE" \
+      $VOLUME_FLAGS \
+      --command "/go_attack/kubernetes/victimplay.sh $RUN_NAME $VOLUME_NAME" \
+      --gpu 1 \
+      --name go-training-"$1"-victimplay \
+      --replicas "${EXTRA_VICTIMPLAY_GPUS}"
+fi


### PR DESCRIPTION
Changes:
  * If `EXTRA_VICTIMPLAY_GPUS` is 0, then we should only launch the `-essentials` job and not the `-victimplay` job, as the `-victimplay` job has 0 replicas.
    * `ctl job run` does error when there are 0 replicas, but before it errors, it creates a persistentvolume that it does not clean up