### PR TITLE
Hotfix: build Python image in launch-jobs.sh

### DIFF
--- a/kubernetes/launch-common.sh
+++ b/kubernetes/launch-common.sh
@@ -9,7 +9,7 @@ if [ "$(git status --porcelain --untracked-files=no | wc -l)" -gt 0 ]; then
 fi
 
 # Maybe build and push new Docker images
-python "$GIT_ROOT"/kubernetes/update_images.py --image cpp
+"$GIT_ROOT"/kubernetes/update_images.py --image cpp
 # Load the env variables just created by update_images.py
 # This line is weird because ShellCheck wants us to put double quotes around the
 # $() context but this changes the behavior to something we don't want

--- a/kubernetes/launch-common.sh
+++ b/kubernetes/launch-common.sh
@@ -8,16 +8,18 @@ if [ "$(git status --porcelain --untracked-files=no | wc -l)" -gt 0 ]; then
     exit 1
 fi
 
-# Maybe build and push new Docker images
-"$GIT_ROOT"/kubernetes/update_images.py --image cpp
-# Load the env variables just created by update_images.py
-# This line is weird because ShellCheck wants us to put double quotes around the
-# $() context but this changes the behavior to something we don't want
-# shellcheck disable=SC2046
-export $(grep -v '^#' "$GIT_ROOT"/kubernetes/active-images.env | xargs)
-
 if [ -n "${USE_WEKA}" ]; then
   export VOLUME_FLAGS="--volume-name go-attack --volume-mount /shared"
 else
   export VOLUME_FLAGS="--shared-host-dir /nas/ucb/k8/go-attack --shared-host-dir-mount /shared"
 fi
+
+update_images () {
+  # Maybe build and push new Docker images
+  "$GIT_ROOT"/kubernetes/update_images.py --image ${@}
+  # Load the env variables just created by update_images.py
+  # This line is weird because ShellCheck wants us to put double quotes around the
+  # $() context but this changes the behavior to something we don't want
+  # shellcheck disable=SC2046
+  export $(grep -v '^#' "$GIT_ROOT"/kubernetes/active-images.env | xargs)
+}

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -64,8 +64,8 @@ MAX_VICTIMPLAY_GPUS=${MAX_VICTIMPLAY_GPUS:-$((2*MIN_VICTIMPLAY_GPUS))}
 RUN_NAME="$1-${RESUME_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
 echo "Run name: $RUN_NAME"
 
-source "$(dirname "$(readlink -f "$0")")"/launch-common.sh
 VOLUME_NAME="shared"
+update_images "cpp python"
 
 # shellcheck disable=SC2215,SC2086,SC2089,SC2090
 ctl job run --container \

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -65,6 +65,7 @@ RUN_NAME="$1-${RESUME_TIMESTAMP:-$(date +%Y%m%d-%H%M%S)}"
 echo "Run name: $RUN_NAME"
 
 VOLUME_NAME="shared"
+source "$(dirname "$(readlink -f "$0")")"/launch-common.sh
 update_images "cpp python"
 
 # shellcheck disable=SC2215,SC2086,SC2089,SC2090

--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -80,6 +80,7 @@ fi
 
 # shellcheck disable=SC1091
 source "$(dirname "$(readlink -f "$0")")"/launch-common.sh
+update_images cpp
 
 if [ -n "${NUM_GAMES}" ]; then
   GAMES_PER_REPLICA=$(((NUM_GAMES + NUM_GPUS - 1) / NUM_GPUS))

--- a/kubernetes/update_images.py
+++ b/kubernetes/update_images.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Automatically build and push new images to Docker Hub if necessary."""
 
 import json


### PR DESCRIPTION
As part of code de-duplication we ended up always building just C++ image. I've refactored the update_images call to be a function and take arguments for what images to build.

I also noticed Python script isn't executable and missing shebang. Seems generally better for script to declare what interpreter it needs rather than relying on callees, so quickly changed it.