### PR TITLE
kubernetes: Log git commit for experiments

### DIFF
--- a/compose/cpp/Dockerfile
+++ b/compose/cpp/Dockerfile
@@ -143,6 +143,10 @@ COPY --from=build-custom-debug /engines/KataGo-custom/cpp/katago /engines/KataGo
 COPY ./configs /go_attack/configs
 
 FROM runtime-deps as prod
+# Make the git commit visible to the image if provided as a --build-arg
+ARG ARG_GIT_COMMIT
+ENV GIT_COMMIT=$ARG_GIT_COMMIT
+
 COPY --from=build-raw /engines/KataGo-raw/cpp/katago /engines/KataGo-raw/cpp/katago
 COPY --from=build-custom /engines/KataGo-custom/cpp/katago /engines/KataGo-custom/cpp/katago
 

--- a/compose/python/Dockerfile
+++ b/compose/python/Dockerfile
@@ -41,6 +41,9 @@ COPY ./compose/python/requirements.txt /downloads/requirements.txt
 RUN pip install --no-cache-dir -r /downloads/requirements.txt
 
 FROM python-deps as prod
+# Make the git commit visible to the image if provided as a --build-arg
+ARG ARG_GIT_COMMIT
+ENV GIT_COMMIT=$ARG_GIT_COMMIT
 # Copy over KataGo python files
 COPY ./engines/KataGo-raw/python /engines/KataGo-raw/python
 COPY ./engines/KataGo-custom/python /engines/KataGo-custom/python

--- a/kubernetes/curriculum.sh
+++ b/kubernetes/curriculum.sh
@@ -2,9 +2,6 @@
 RUN_NAME="$1"
 VOLUME_NAME="$2"
 
-# not related to curriculum but we want some process to log this
-/go_attack/kubernetes/log-git-commit.sh /"$VOLUME_NAME"/victimplay/"$RUN_NAME"
-
 python /engines/KataGo-custom/python/curriculum.py \
     -selfplay-dir=/"$VOLUME_NAME"/victimplay/"$RUN_NAME"/selfplay/ \
     -input-models-dir=/"$VOLUME_NAME"/victims \

--- a/kubernetes/curriculum.sh
+++ b/kubernetes/curriculum.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 RUN_NAME="$1"
 VOLUME_NAME="$2"
+
+# not related to curriculum but we want some process to log this
+/go_attack/kubernetes/log-git-commit.sh /"$VOLUME_NAME"/victimplay/"$RUN_NAME"
+
 python /engines/KataGo-custom/python/curriculum.py \
     -selfplay-dir=/"$VOLUME_NAME"/victimplay/"$RUN_NAME"/selfplay/ \
     -input-models-dir=/"$VOLUME_NAME"/victims \

--- a/kubernetes/log-git-commit.sh
+++ b/kubernetes/log-git-commit.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+# Logs the git commit (assumed to be saved in the GIT_COMMIT environment
+# variable) used for an experiment.
+
+OUTPUT_DIR=$1
+
+mkdir -p "$OUTPUT_DIR"
+COMMIT_FILE="$OUTPUT_DIR"/commit
+GIT_COMMIT=${GIT_COMMIT:-no_commit_found}
+
+if [ -f "$COMMIT_FILE" ]; then
+  LATEST_COMMIT=$(tail -n 1 "$COMMIT_FILE" | awk '{print $2}')
+  if [ "$LATEST_COMMIT" != "$GIT_COMMIT" ]; then
+    echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"
+  fi
+else
+  echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"
+fi

--- a/kubernetes/log-git-commit.sh
+++ b/kubernetes/log-git-commit.sh
@@ -9,12 +9,10 @@ COMMIT_FILE="$OUTPUT_DIR"/commit
 GIT_COMMIT=${GIT_COMMIT:-no_commit_found}
 
 if [ -f "$COMMIT_FILE" ]; then
-  # COMMIT_FILE already exists, but we may still want to log the commit if the
-  # commit has changed due to restarting a job.
   LATEST_COMMIT=$(tail -n 1 "$COMMIT_FILE" | awk '{print $2}')
-  if [ "$LATEST_COMMIT" != "$GIT_COMMIT" ]; then
-    echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"
+  if [ "$LATEST_COMMIT" = "$GIT_COMMIT" ]; then
+    exit 0
   fi
-else
-  echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"
 fi
+
+echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"

--- a/kubernetes/log-git-commit.sh
+++ b/kubernetes/log-git-commit.sh
@@ -9,6 +9,8 @@ COMMIT_FILE="$OUTPUT_DIR"/commit
 GIT_COMMIT=${GIT_COMMIT:-no_commit_found}
 
 if [ -f "$COMMIT_FILE" ]; then
+  # COMMIT_FILE already exists, but we may still want to log the commit if the
+  # commit has changed due to restarting a job.
   LATEST_COMMIT=$(tail -n 1 "$COMMIT_FILE" | awk '{print $2}')
   if [ "$LATEST_COMMIT" != "$GIT_COMMIT" ]; then
     echo "$(date +%Y%m%d-%H%M%S) $GIT_COMMIT" >> "$COMMIT_FILE"

--- a/kubernetes/match.sh
+++ b/kubernetes/match.sh
@@ -8,8 +8,10 @@ OUTPUT_DIR=$1
 NUM_GAMES=$2
 VICTIM=$3
 ADVERSARY=$4
-
 shift 4
+
+/go_attack/kubernetes/log-git-commit.sh "$OUTPUT_DIR"
+
 if [ "${NUM_GAMES}" -ge 0 ]; then
   GAMES_OVERRIDE="-override-config numGamesTotal=${NUM_GAMES}"
 fi

--- a/kubernetes/shuffle-and-export.sh
+++ b/kubernetes/shuffle-and-export.sh
@@ -3,6 +3,10 @@ cd /engines/KataGo-custom/python
 RUN_NAME="$1"
 DIRECTORY="$2"
 VOLUME_NAME="$3"
+
+# not related to shuffle-and-export but we want some process to log this
+/go_attack/kubernetes/log-git-commit.sh /"$VOLUME_NAME"/victimplay/"$RUN_NAME"
+
 mkdir -p /"$VOLUME_NAME"/victimplay/"$DIRECTORY"
 ./selfplay/shuffle_and_export_loop.sh    "$RUN_NAME"    /"$VOLUME_NAME"/victimplay/"$DIRECTORY"    /tmp    16    256    0
 sleep infinity

--- a/kubernetes/update_images.py
+++ b/kubernetes/update_images.py
@@ -35,8 +35,6 @@ def main():
     # We use the Git hash to tag our images. Find the current hash.
     hash_raw = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
     current_hash = hash_raw.decode("ascii").strip()
-    long_hash_raw = subprocess.check_output(["git", "rev-parse", "HEAD"])
-    current_long_hash = long_hash_raw.decode("ascii").strip()
 
     # The "tag" string actually includes the repo name as well
     # (e.g. "humancompatibleai/goattack:c27e251"). These are all
@@ -67,7 +65,7 @@ def main():
             path=rootdir,
             dockerfile=f"compose/{image_type}/Dockerfile",
             tag=image_name,
-            buildargs={"ARG_GIT_COMMIT": current_long_hash},
+            buildargs={"ARG_GIT_COMMIT": current_hash},
         )
         # Pylance can't quite figure out the type of build_result; see
         # https://docker-py.readthedocs.io/en/stable/images.html#image-objects for info

--- a/kubernetes/update_images.py
+++ b/kubernetes/update_images.py
@@ -35,6 +35,8 @@ def main():
     # We use the Git hash to tag our images. Find the current hash.
     hash_raw = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
     current_hash = hash_raw.decode("ascii").strip()
+    long_hash_raw = subprocess.check_output(["git", "rev-parse", "HEAD"])
+    current_long_hash = long_hash_raw.decode("ascii").strip()
 
     # The "tag" string actually includes the repo name as well
     # (e.g. "humancompatibleai/goattack:c27e251"). These are all
@@ -65,6 +67,7 @@ def main():
             path=rootdir,
             dockerfile=f"compose/{image_type}/Dockerfile",
             tag=image_name,
+            buildargs={"ARG_GIT_COMMIT": current_long_hash},
         )
         # Pylance can't quite figure out the type of build_result; see
         # https://docker-py.readthedocs.io/en/stable/images.html#image-objects for info


### PR DESCRIPTION
## Description

### Changes

Logs the git commit for an experiment in a `commit` file:
* `kubernetes/update_images.py` passes in the git commit as a `--build-arg`, which is saved as environment variable `GIT_COMMIT` inside the image
* `kubernetes/log-git-commit.sh` logs a timestamp and commit into a file called `commit` in the experiment output directory

### Other notes

(optional reading)

We also discussed logging the Docker digest/hash, which I did not implement in this PR. A few reasons:
* ideally the git commit is enough to look up the image in Docker Hub or to rebuild the image
* docker digests are kinda confusing — there's the digest you see on Docker Hub, then there's the platform-specific digest you get [when you pull from Docker Hub](https://github.com/docker/hub-feedback/issues/1925), and then there's the image ID, all of which are different
  * but I think in summary we can get the digest you see on Docker Hub via `docker inspect --format='{{index .RepoDigests 0}}' <image>`, and then that digest can be used to pull images (`docker pull humancompatibleai/goattack@sha256:<digest>`)
* it's slightly more annoying to log because it can't be saved as an environment info inside the image (the image needs to be built and pushed before we can get a digest for it). So we'd need to fetch the digest in `launch-job.sh` and plumb it through as an argument to `log-git-commit.sh`

## Testing
* launched two `match` replicas and checked that `commit` file was populated
  * it's probably possible that multiple `match` replicas will race and write to the `commit` file simultaneously, but I'd guess this is rare and unimportant enough that it's OK if `commit` is occasionally messed up
* launched a `curriculum` replica and checked that `commit` file was populated
* ran `kubernetes/log-git-commit.sh` a few times locally and checked that a new line is added to `commit` if `GIT_COMMIT` changes