### PR TITLE
kubernetes: Shorten job name

### DIFF
--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -83,7 +83,7 @@ ctl job run --container \
     "/go_attack/kubernetes/curriculum.sh $RUN_NAME $VOLUME_NAME" \
     --high-priority \
     --gpu 1 1 1 0 0 \
-    --name go-train-"$1"-vital \
+    --name go-train-"$1"-main \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1
 
 EXTRA_VICTIMPLAY_GPUS=$((MAX_VICTIMPLAY_GPUS-MIN_VICTIMPLAY_GPUS))

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -83,7 +83,7 @@ ctl job run --container \
     "/go_attack/kubernetes/curriculum.sh $RUN_NAME $VOLUME_NAME" \
     --high-priority \
     --gpu 1 1 1 0 0 \
-    --name go-training-"$1"-essentials \
+    --name go-train-"$1"-vital \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1
 
 EXTRA_VICTIMPLAY_GPUS=$((MAX_VICTIMPLAY_GPUS-MIN_VICTIMPLAY_GPUS))
@@ -94,6 +94,6 @@ if [ $EXTRA_VICTIMPLAY_GPUS -gt 0 ]; then
       $VOLUME_FLAGS \
       --command "/go_attack/kubernetes/victimplay.sh $RUN_NAME $VOLUME_NAME" \
       --gpu 1 \
-      --name go-training-"$1"-victimplay \
+      --name go-train-"$1"-extra \
       --replicas "${EXTRA_VICTIMPLAY_GPUS}"
 fi

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -83,7 +83,7 @@ ctl job run --container \
     "/go_attack/kubernetes/curriculum.sh $RUN_NAME $VOLUME_NAME" \
     --high-priority \
     --gpu 1 1 1 0 0 \
-    --name go-train-"$1"-main \
+    --name go-train-"$1"-vital \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1
 
 EXTRA_VICTIMPLAY_GPUS=$((MAX_VICTIMPLAY_GPUS-MIN_VICTIMPLAY_GPUS))


### PR DESCRIPTION
Context: `ctl` only allows jobs with up to ~50 characters, otherwise we hit Kubernetes' [63-character name limit](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) after appending `-launch-0-0` or a random volume-mount suffix. I've hit the character limit several times due to having verbose names.

Changes: This PR changes `kubernetes/launch-job.sh` to make the job name be `go-train-$PREFIX-{vital,extra}` instead of `go-training-$PREFIX-{essentials,victimplay}`, saving a few extra characters that can be used for $PREFIX. 