### PR TITLE
launch-match: Remove required victim/adversary arguments

### DIFF
--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -9,14 +9,12 @@ DEFAULT_NUM_GPUS=1
 usage() {
   echo "Schedules a job that runs \`match\`."
   echo
-  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] [--use-weka] PREFIX VICTIM ADVERSARY"
+  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] [--use-weka] PREFIX"
   echo "          [--EXTRA_MATCH_FLAGS]"
   echo
   echo "positional arguments:"
   echo "  PREFIX     Identifying label used for the name of the job and the name"
   echo "             of the output directory."
-  echo "  VICTIM     Filename of the victim checkpoint inside the container."
-  echo "  ADVERSARY  Filename of the adversary checkpoint inside the container."
   echo
   echo "optional arguments:"
   echo "  -g GPUS, --gpus GPUS"
@@ -37,7 +35,7 @@ usage() {
   echo "  $0 test-run -- -override-config nnModelFile0=/dev/null"
 }
 
-NUM_POSITIONAL_ARGUMENTS=3
+NUM_POSITIONAL_ARGUMENTS=1
 
 NUM_GPUS=${DEFAULT_NUM_GPUS}
 # Command line flag parsing (https://stackoverflow.com/a/33826763/4865149)
@@ -58,11 +56,9 @@ if [ $# -lt ${NUM_POSITIONAL_ARGUMENTS} ]; then
 fi
 
 PREFIX=$1
-VICTIM=$2
-ADVERSARY=$3
 RUN_NAME="$PREFIX-$(date +%Y%m%d-%H%M%S)"
 echo "Run name: $RUN_NAME"
-shift 3
+shift $NUM_POSITIONAL_ARGUMENTS
 
 if [ $# -gt 0 ]; then
   if [ "$1" != "--" ]; then
@@ -96,9 +92,8 @@ ctl job run --container \
   /go_attack/kubernetes/match.sh
   /shared/match/${RUN_NAME}
   ${GAMES_PER_REPLICA}
-  ${VICTIM}
-  ${ADVERSARY}
   $*" \
+  --high-priority \
   --gpu 1 \
   --name go-match-"$PREFIX" \
   --replicas "${NUM_GPUS}"

--- a/kubernetes/match.sh
+++ b/kubernetes/match.sh
@@ -6,9 +6,7 @@
 
 OUTPUT_DIR=$1
 NUM_GAMES=$2
-VICTIM=$3
-ADVERSARY=$4
-shift 4
+shift 2
 
 /go_attack/kubernetes/log-git-commit.sh "$OUTPUT_DIR"
 
@@ -25,6 +23,4 @@ mkdir --parents "${OUTPUT_DIR}"
   -config /go_attack/configs/compute/1gpu.cfg \
   -sgf-output-dir "${OUTPUT_DIR}"/sgfs \
   -log-file "${OUTPUT_DIR}"/match-"${ID}".log \
-  -override-config nnModelFile0="${VICTIM}" \
-  -override-config nnModelFile1="${ADVERSARY}" \
   $GAMES_OVERRIDE $@


### PR DESCRIPTION
Changes to `kubernetes/launch-match.sh`
* Remove `VICTIM` and `ADVERSARY` positional arguments
  * We don't always want to launch a match between two bots. I recently launched an experiment where I had a config file with ~10 bots and I didn't want to have to specify `VICTIM` and `ADVERSARY. 
  * If the user of `launch-match` wants to override the models specified in the config file, they can do `./launch-match <jobname> -- -override-config nnModelFile0=...` instead
* Make the launched job have `--high-priority`
  * we want these jobs to have priority over the low-priority extra victimplay workers launched by `kubernetes/launch-job.sh` 