### PR TITLE
Support transfer experiments with KataGo-raw

### DIFF
--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -88,7 +88,7 @@ services:
         2>&1 | tee --append /outputs/attack.log
       "
 
-  katago:
+  katago: &katago
     profiles:
       - katago
     image: humancompatibleai/goattack:cpp
@@ -136,28 +136,9 @@ services:
               device_ids: ["${GPU:-0}"]
 
   katago-raw:
+    <<: *katago
     profiles:
       - katago-raw
-    image: humancompatibleai/goattack:cpp
-    build:
-      context: ${HOST_REPO_ROOT}
-      dockerfile: ${HOST_REPO_ROOT}/compose/cpp/Dockerfile
-      target: prod
-    volumes:
-      - type: bind
-        source: ${HOST_OUTPUT_DIR}
-        target: /outputs
-      - type: bind
-        source: ${HOST_REPO_ROOT}/configs
-        target: ${HOST_REPO_ROOT}/configs
-        read_only: true
-      # We prefix the target of KATAGO_MODEL and KATAGO_VICTIM_MODEL differently
-      # so that Docker doesn't complain about duplicate volumes when
-      # KATAGO_MODEL == KATAGO_VICTIM_MODEL
-      - type: bind
-        source: ${KATAGO_VICTIM_MODEL}
-        target: /victim-model/${KATAGO_VICTIM_MODEL}
-        read_only: true
     command: >
       sh -c "
         socat TCP4-LISTEN:80,reuseaddr \
@@ -168,13 +149,6 @@ services:
           \" \
         2>&1 | tee --append /outputs/katago-raw.log
       "
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - capabilities: ["gpu"]
-              driver: nvidia
-              device_ids: ["${GPU:-0}"]
 
   twogtp:
     profiles:

--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -134,6 +134,48 @@ services:
             - capabilities: ["gpu"]
               driver: nvidia
               device_ids: ["${GPU:-0}"]
+
+  katago-raw:
+    profiles:
+      - katago-raw
+    image: humancompatibleai/goattack:cpp
+    build:
+      context: ${HOST_REPO_ROOT}
+      dockerfile: ${HOST_REPO_ROOT}/compose/cpp/Dockerfile
+      target: prod
+    volumes:
+      - type: bind
+        source: ${HOST_OUTPUT_DIR}
+        target: /outputs
+      - type: bind
+        source: ${HOST_REPO_ROOT}/configs
+        target: ${HOST_REPO_ROOT}/configs
+        read_only: true
+      # We prefix the target of KATAGO_MODEL and KATAGO_VICTIM_MODEL differently
+      # so that Docker doesn't complain about duplicate volumes when
+      # KATAGO_MODEL == KATAGO_VICTIM_MODEL
+      - type: bind
+        source: ${KATAGO_VICTIM_MODEL}
+        target: /victim-model/${KATAGO_VICTIM_MODEL}
+        read_only: true
+    command: >
+      sh -c "
+        socat TCP4-LISTEN:80,reuseaddr \
+        EXEC:\"/engines/KataGo-raw/cpp/katago gtp \
+          -config ${HOST_REPO_ROOT}/configs/raw-gtp.cfg \
+          -model /victim-model/${KATAGO_VICTIM_MODEL} \
+          -override-config multiStoneSuicideLegal=false \
+          \" \
+        2>&1 | tee --append /outputs/katago-raw.log
+      "
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: ["gpu"]
+              driver: nvidia
+              device_ids: ["${GPU:-0}"]
+
   twogtp:
     profiles:
       - katago

--- a/compose/transfer/launch.sh
+++ b/compose/transfer/launch.sh
@@ -60,7 +60,7 @@ function usage() {
   echo "positional arguments:"
   echo "  EXPERIMENT  Which experiment to run."
   echo "              values: {baseline-attack-vs-elf, baseline-attack-vs-leela,"
-  echo "                       katago-vs-elf, katago-vs-leela}"
+  echo "                       katago-vs-elf, katago-vs-leela, katago-vs-katago-raw}"
   echo "  COMMAND     docker-compose command to run."
   echo "              values: {build, up}"
   echo

--- a/configs/raw-gtp.cfg
+++ b/configs/raw-gtp.cfg
@@ -19,7 +19,7 @@ conservativePass = false
 logAllGTPCommunication = false
 
 
-# Copy-pasted from emcts1/base.cfg
+# Copied from emcts1/base.cfg, removing entries ending in a player index to support KataGo master
 # other options
 useAuxPolicyTarget = true
 

--- a/configs/raw-gtp.cfg
+++ b/configs/raw-gtp.cfg
@@ -1,31 +1,9 @@
-numGameThreads = 200
-
-# GPU Settings-------------------------------------------------------------------------------
-# 1xA6000
-# 2 sockets of AMD EPYC 7763 64-Core Processors = 128 physical cores
-#                                                 each core has 2 threads
-
-nnMaxBatchSize = 256
-nnCacheSizePowerOfTwo = 24
-nnMutexPoolSizePowerOfTwo = 18
-numNNServerThreadsPerModel = 4
-nnRandomize = true
-
-# CUDA GPU settings--------------------------------------
-# cudaDeviceToUse = 0 #use device 0 for all server threads (numNNServerThreadsPerModel) unless otherwise specified per-model or per-thread-per-model
-# cudaDeviceToUseModel0 = 3 #use device 3 for model 0 for all threads unless otherwise specified per-thread for this model
-# cudaDeviceToUseModel1 = 2 #use device 2 for model 1 for all threads unless otherwise specified per-thread for this model
-# cudaDeviceToUseModel0Thread0 = 3 #use device 3 for model 0, server thread 0
-# cudaDeviceToUseModel0Thread1 = 2 #use device 2 for model 0, server thread 1
-
-deviceToUseThread0 = 0
-deviceToUseThread1 = 0
-deviceToUseThread2 = 0
-deviceToUseThread3 = 0
-
-useFP16 = true
-# We only set NHWC for CUDA because TensorRT requires useNHWC == false.
-cudaUseNHWC = true
+@include compute/1gpu.cfg
+@include emcts1/components/board-sizes.cfg
+@include emcts1/components/game-init.cfg
+@include emcts1/components/komi-handicap.cfg
+@include emcts1/components/logs.cfg
+@include emcts1/components/rules.cfg
 
 ponderingEnabled = false
 
@@ -138,69 +116,3 @@ subtreeValueBiasWeightExponent = 0.8
 
 mutexPoolSize = 64
 numVirtualLossesPerThread = 1
-
-# Copy-pasted from emcts1/components/board-sizes.cfg
-# Which board sizes we play on.
-
-bSizes = 7,9,11,13,15,17,19,  8,10,12,14,16,18
-bSizeRelProbs = 1,4,3,10,7,9,35, 1,2,4,6,8,10
-allowRectangleProb = 0.00
-
-maxMovesPerGame = 1600
-
-# Copy-pasted from emcts1/components/game-init.cfg
-initGamesWithPolicy = false
-policyInitAreaProp = 0
-compensateAfterPolicyInitProb = 0
-sidePositionProb = 0
-
-
-# Copy-pasted from emcts1/components/komi-handicap.cfg
-# Parameters affecting komi and handicap.
-
-# We make komi a constant 6.5, which is the most common komi per
-# https://en.wikipedia.org/wiki/Komi_(Go)
-# komiMean = 6.5
-komiStdev = 0
-komiBigStdevProb = 0
-komiBigStdev = 0
-
-# Taken from lightvector's analysis in https://lifein19x19.com/viewtopic.php?f=15&t=17750
-# Board size: 7,    8,    9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19
-komiByBSize = 8.5, 9.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5
-
-komiAuto = false
-fancyKomiVarying = false
-
-minAsymmetricCompensateKomiProb = 0
-handicapCompensateKomiProb = 0
-forkCompensateKomiProb = 0
-sgfCompensateKomiProb = 0
-
-# We never play handicap games.
-handicapProb = 0
-
-
-# Copy-pasted from emcts1/components/logs.cfg
-# Logging configuration
-
-logSearchInfo = false
-logMoves = false
-logGamesEvery = 20
-logToStdout = true
-
-
-# Copy-pasted from emcts1/components/rules.cfg
-# Used by match and victimplay.
-koRules = POSITIONAL
-scoringRules = AREA
-taxRules = NONE
-multiStoneSuicideLegals = true
-hasButtons = false
-
-# Used by gtp.
-koRule = POSITIONAL
-scoringRule = AREA
-taxRule = NONE
-multiStoneSuicideLegal = true
-hasButton = false

--- a/configs/raw-gtp.cfg
+++ b/configs/raw-gtp.cfg
@@ -1,0 +1,179 @@
+@include compute/1gpu.cfg
+
+ponderingEnabled = false
+
+allowResignation = false
+resignConsecTurns = 3
+resignThreshold = -0.95
+
+maxVisits = 32
+# conservativePass defaults to true for GTP, but it's false for match and
+# selfplay
+conservativePass = false
+
+logAllGTPCommunication = false
+
+
+# Copy-pasted from emcts1/base.cfg
+# other options
+useAuxPolicyTarget = true
+
+# Data writing------------------------------------------------------------------------------------
+
+dataBoardLen = 19
+maxDataQueueSize = 2000
+maxRowsPerTrainFile = 25000
+maxRowsPerValFile = 5000
+firstFileRandMinProp = 0.15
+
+validationProp = 0.00
+
+# Fancy game selfplay settings--------------------------------------------------------------------
+earlyForkGameProb = 0
+earlyForkGameExpectedMoveProp = 0.025
+forkGameProb = 0
+forkGameMinChoices = 3
+earlyForkGameMaxChoices = 12
+forkGameMaxChoices = 36
+sekiForkHackProb = 0
+
+cheapSearchProb = 0
+cheapSearchVisits = 100
+cheapSearchTargetWeight = 0.0
+
+reduceVisits = false
+reduceVisitsThreshold = 0.9
+reduceVisitsThresholdLookback = 3
+reducedVisitsMin = 100
+reducedVisitsWeight = 0.1
+
+handicapAsymmetricPlayoutProb = 0
+normalAsymmetricPlayoutProb = 0
+maxAsymmetricRatio = 8.0
+
+policySurpriseDataWeight = 0.5
+valueSurpriseDataWeight = 0.1
+
+estimateLeadProb = 0.45
+switchNetsMidGame = false
+
+# Draws-------------------------------------------------------------------------------------------
+
+drawRandRadius = 0.5
+noResultStdev = 0.166666666
+
+# Search limits-----------------------------------------------------------------------------------
+
+numSearchThreads = 1
+
+# Root move selection and biases------------------------------------------------------------------
+
+chosenMoveTemperatureEarly = 0.75
+chosenMoveTemperatureHalflife = 19
+chosenMoveTemperature = 0.15
+chosenMoveSubtract = 0
+chosenMovePrune = 1
+
+rootNoiseEnabled = true
+rootDirichletNoiseTotalConcentration = 10.83
+rootDirichletNoiseWeight = 0.25
+
+rootDesiredPerChildVisitsCoeff = 2
+rootNumSymmetriesToSample = 4
+
+useLcbForSelection = true
+lcbStdevs = 5.0
+minVisitPropForLCB = 0.15
+
+# Internal params---------------------------------------------------------------------------------
+
+winLossUtilityFactor = 1.0
+staticScoreUtilityFactor = 0.00
+dynamicScoreUtilityFactor = 0.40
+dynamicScoreCenterZeroWeight = 0.25
+dynamicScoreCenterScale = 0.50
+noResultUtilityForWhite = 0.0
+drawEquivalentWinsForWhite = 0.5
+
+rootEndingBonusPoints = 0.5
+rootPruneUselessMoves = true
+
+rootPolicyTemperatureEarly = 1.25
+rootPolicyTemperature = 1.1
+
+cpuctExploration = 1.1
+cpuctExplorationLog = 0.0
+fpuReductionMax = 0.2
+rootFpuReductionMax = 0.0
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+
+mutexPoolSize = 64
+numVirtualLossesPerThread = 1
+
+# Copy-pasted from emcts1/components/board-sizes.cfg
+# Which board sizes we play on.
+
+bSizes = 7,9,11,13,15,17,19,  8,10,12,14,16,18
+bSizeRelProbs = 1,4,3,10,7,9,35, 1,2,4,6,8,10
+allowRectangleProb = 0.00
+
+maxMovesPerGame = 1600
+
+# Copy-pasted from emcts1/components/game-init.cfg
+initGamesWithPolicy = false
+policyInitAreaProp = 0
+compensateAfterPolicyInitProb = 0
+sidePositionProb = 0
+
+
+# Copy-pasted from emcts1/components/komi-handicap.cfg
+# Parameters affecting komi and handicap.
+
+# We make komi a constant 6.5, which is the most common komi per
+# https://en.wikipedia.org/wiki/Komi_(Go)
+# komiMean = 6.5
+komiStdev = 0
+komiBigStdevProb = 0
+komiBigStdev = 0
+
+# Taken from lightvector's analysis in https://lifein19x19.com/viewtopic.php?f=15&t=17750
+# Board size: 7,    8,    9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19
+komiByBSize = 8.5, 9.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5, 6.5
+
+komiAuto = false
+fancyKomiVarying = false
+
+minAsymmetricCompensateKomiProb = 0
+handicapCompensateKomiProb = 0
+forkCompensateKomiProb = 0
+sgfCompensateKomiProb = 0
+
+# We never play handicap games.
+handicapProb = 0
+
+
+# Copy-pasted from emcts1/components/logs.cfg
+# Logging configuration
+
+logSearchInfo = false
+logMoves = false
+logGamesEvery = 20
+logToStdout = true
+
+
+# Copy-pasted from emcts1/components/rules.cfg
+# Used by match and victimplay.
+koRules = POSITIONAL
+scoringRules = AREA
+taxRules = NONE
+multiStoneSuicideLegals = true
+hasButtons = false
+
+# Used by gtp.
+koRule = POSITIONAL
+scoringRule = AREA
+taxRule = NONE
+multiStoneSuicideLegal = true
+hasButton = false

--- a/configs/raw-gtp.cfg
+++ b/configs/raw-gtp.cfg
@@ -1,4 +1,31 @@
-@include compute/1gpu.cfg
+numGameThreads = 200
+
+# GPU Settings-------------------------------------------------------------------------------
+# 1xA6000
+# 2 sockets of AMD EPYC 7763 64-Core Processors = 128 physical cores
+#                                                 each core has 2 threads
+
+nnMaxBatchSize = 256
+nnCacheSizePowerOfTwo = 24
+nnMutexPoolSizePowerOfTwo = 18
+numNNServerThreadsPerModel = 4
+nnRandomize = true
+
+# CUDA GPU settings--------------------------------------
+# cudaDeviceToUse = 0 #use device 0 for all server threads (numNNServerThreadsPerModel) unless otherwise specified per-model or per-thread-per-model
+# cudaDeviceToUseModel0 = 3 #use device 3 for model 0 for all threads unless otherwise specified per-thread for this model
+# cudaDeviceToUseModel1 = 2 #use device 2 for model 1 for all threads unless otherwise specified per-thread for this model
+# cudaDeviceToUseModel0Thread0 = 3 #use device 3 for model 0, server thread 0
+# cudaDeviceToUseModel0Thread1 = 2 #use device 2 for model 0, server thread 1
+
+deviceToUseThread0 = 0
+deviceToUseThread1 = 0
+deviceToUseThread2 = 0
+deviceToUseThread3 = 0
+
+useFP16 = true
+# We only set NHWC for CUDA because TensorRT requires useNHWC == false.
+cudaUseNHWC = true
 
 ponderingEnabled = false
 


### PR DESCRIPTION
Unfortunately due to the apparent discrepancies between `analysis` and (our version of) `match`, it's become necessary to check that our attacks "transfer" to `KataGo-raw`.

The `raw-gtp.cfg` file is necessary because `KataGo-raw` doesn't support config options with player indices in GTP mode. Also it forces you to specify explicitly that `ponderingEnabled=false`.