### PR TITLE
scripts: Add script to rescore SGFs using KataGo

### DIFF
--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -121,9 +121,12 @@ def main():
             num_flipped_games += 1
 
         print(f"KataGo score: {katago_score}, original score: {original_score}")
-    os.remove(tmp_sgf_path)
-    print(f"Flipped games: {num_flipped_games}/{num_games}")
-    print(f"Mean squared error: {squared_error_sum / num_games}")
+    if num_games > 0:
+        tmp_sgf_path.unlink()
+        print(f"Flipped games: {num_flipped_games}/{num_games}")
+        print(f"Mean squared error: {squared_error_sum / num_games}")
+    else:
+        print("No games found.")
 
 
 if __name__ == "__main__":

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -158,7 +158,7 @@ def main():
             sgf.get_root().set("RE", katago_score_str)
             output_file.write(sgf.serialise(wrap=None))
     if num_games > 0:
-        print(f"Flipped games: {num_flipped_games}/{num_games}")
+        print(f"Games that changed winners: {num_flipped_games}/{num_games}")
         print(f"Mean squared error: {squared_error_sum / num_games}")
     else:
         print("No games found.")

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -60,10 +60,7 @@ def main():
     parser.add_argument(
         "sgf_path",
         type=Path,
-        help=(
-            "Path to directory (to be searched recursively) containing input "
-            "SGFs. The SGF files are expected to contain one SGF per file."
-        ),
+        help="Path to directory (to be searched recursively) with input SGFs",
     )
     parser.add_argument(
         "-o",

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -66,11 +66,8 @@ def main():
         ),
     )
     parser.add_argument(
-        "-o",
-        "--output",
-        type=Path,
-        help="Path to file to contain output SGFs",
-        default=os.devnull,
+        "-o", "--output", type=Path, help="Path to file to contain output SGFs",
+        default=os.devnull
     )
     args = parser.parse_args()
     if args.output.is_file():
@@ -102,20 +99,27 @@ def main():
         to_engine.write(f"{message}\n".encode("ascii"))
         output = ""
         found_output_start = False
+        success = False
         for i, line in enumerate(from_engine):
             line = line.decode("ascii")
 
             if found_output_start and line.strip() == "":
-                # Blank line signals the end of a response
+                # Blank line signals the end of a response.
                 break
 
-            if not found_output_start and line[0] == "=":
-                found_output_start = True
-                output += line[1:]
+            if not found_output_start:
+                if line[0] == "?":
+                    # Error response, no success.
+                    found_output_start = True
+                    output += line[1:]
+                elif line[0] == "=":
+                    success = True
+                    found_output_start = True
+                    output += line[1:]
             else:
                 output += line
         if assert_success:
-            assert found_output_start
+            assert success
         return output.lstrip().strip()
 
     num_games = 0
@@ -156,7 +160,6 @@ def main():
     else:
         print("No games found.")
     shutil.rmtree(tmp_dir)
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -66,7 +66,7 @@ def main():
         "-o",
         "--output",
         type=Path,
-        help="Path to file to contain output SGFs",
+        help="Path to file to write output SGFs",
         default=os.devnull,
     )
     args = parser.parse_args()

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -66,8 +66,11 @@ def main():
         ),
     )
     parser.add_argument(
-        "-o", "--output", type=Path, help="Path to file to contain output SGFs",
-        default=os.devnull
+        "-o",
+        "--output",
+        type=Path,
+        help="Path to file to contain output SGFs",
+        default=os.devnull,
     )
     args = parser.parse_args()
     if args.output.is_file():
@@ -160,6 +163,7 @@ def main():
     else:
         print("No games found.")
     shutil.rmtree(tmp_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -1,0 +1,99 @@
+import argparse
+import os
+from pathlib import Path
+import subprocess
+
+import sgfmill.sgf
+
+
+def get_sgf_score(sgf_file: Path):
+    """Get score listed in SGF file."""
+    with open(sgf_file) as f:
+        return sgfmill.sgf.Sgf_game.from_string(f.read()).get_root().get("RE")
+
+
+def get_sgf_files_in_path(path: Path):
+    """Recursively get all SGF files in the path."""
+    if path.suffix in [".sgf", ".sgfs"]:
+        yield str(path)
+    for dirpath, _, filenames in os.walk(path):
+        for f in filenames:
+            f_path = Path(os.path.join(dirpath, f))
+            if f_path.suffix in [".sgf", ".sgfs"]:
+                yield str(f_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rescores SGFs using KataGo's Tromp-Taylor scoring."
+    )
+    parser.add_argument(
+        "sgf_path",
+        type=Path,
+        help=(
+            "Path to directory (to be searched recursively) containing input "
+            "SGFs. The SGF files are expected to contain one SGF per file."
+        ),
+    )
+    parser.add_argument(
+        "--katago_command",
+        type=str,
+        help="Command with which to run KataGo in GTP mode",
+    )
+    # parser.add_argument(
+    #     "-o", "--output", type=Path, help="Path to directory at which to output SGFs"
+    # )
+
+    args = parser.parse_args()
+    if args.katago_command is None:
+        args.katago_command = (
+            "docker run --gpus '\"device=0\"' "
+            f"-v {args.sgf_path}:{args.sgf_path} -i "
+            "humancompatibleai/goattack:cpp "
+            "/engines/KataGo-raw/cpp/katago gtp "
+            "-config /engines/KataGo-raw/cpp/configs/gtp_example.cfg "
+            "-model /dev/null"
+        )
+
+    proc = subprocess.Popen(
+        args.katago_command,
+        bufsize=0,
+        shell=True,
+        stderr=open("/tmp/score-with-katago.stderr", "w"),
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+    to_engine = proc.stdin
+    from_engine = proc.stdout
+
+    def write_to_engine(message):
+        to_engine.write(message.encode("ascii"))
+
+        output = ""
+        found_output_start = False
+        for i, line in enumerate(from_engine):
+            line = line.decode("ascii")
+
+            if found_output_start and line.strip() == "":
+                # Blank line signals the end of a response
+                break
+
+            if not found_output_start and line[0] == "=":
+                found_output_start = True
+                output += line[1:]
+            else:
+                output += line
+        return output.lstrip().strip(), found_output_start
+
+    for path in get_sgf_files_in_path(args.sgf_path):
+        _, success = write_to_engine(f"loadsgf {path}\n")
+        assert success
+        _, success = write_to_engine("kata-set-rules Tromp-Taylor\n")
+        assert success
+        katago_score, success = write_to_engine("final_score\n")
+
+        print(f"KataGo score: {katago_score}, orig score: {get_sgf_score(path)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/score_with_katago.py
+++ b/scripts/score_with_katago.py
@@ -66,8 +66,11 @@ def main():
         ),
     )
     parser.add_argument(
-        "-o", "--output", type=Path, help="Path to file to contain output SGFs",
-        default=os.devnull
+        "-o",
+        "--output",
+        type=Path,
+        help="Path to file to contain output SGFs",
+        default=os.devnull,
     )
     args = parser.parse_args()
     if args.output.is_file():
@@ -153,6 +156,7 @@ def main():
     else:
         print("No games found.")
     shutil.rmtree(tmp_dir)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Description

### Context

KataGo scoring clears out opposite-color stones within pass-alive groups. For consistency throughout experiments, we should use KataGo scoring everywhere (including in experiments where otherwise KataGo isn't involved at all like baseline attacks vs. ELF).

### Changes

Adds script that rescores SGFs using KataGo.

## Testing

* Run `python scripts/score_with_katago.py /nas/ucb/ttseng/go_attack/match/adv-checkpoints/0-redo/sgfs/`
  * Here we expect no change in scores since these are KataGo `match` games
* Run  `python scripts/score_with_katago.py /nas/ucb/ttseng/go_attack/transfer/`
  * Here we expect changes in score since these are scored without analyzing pass-alive groups
  * Mean squared error from score changes: 274.4 (no games changed winners though)
 