### PR TITLE
Curriculum: Update win rate threshold and max visits

### DIFF
--- a/configs/curriculum.json
+++ b/configs/curriculum.json
@@ -3,7 +3,7 @@
         "_comment": "cp127@1",
         "name": "kata1-b20c256x2-s5303129600-d1228401921.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5,
+        "win_rate": 0.75,
         "score_diff": null,
         "score_wo_komi_diff": null,
         "policy_loss": null
@@ -12,96 +12,96 @@
         "_comment": "cp200@1",
         "name": "kata1-b40c256-s5867950848-d1413392747.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp300@1",
         "name": "kata1-b40c256-s7455877888-d1808582493.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp400@1",
         "name": "kata1-b40c256-s9738904320-d2372933741.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp469@1",
         "name": "kata1-b40c256-s11101799168-d2715431527.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@1",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 1,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@2",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 2,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@4",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 4,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@8",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 8,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@16",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 16,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@32",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 32,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@64",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 64,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@128",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 128,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@256",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 256,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@512",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 512,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@1024",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 1024,
-        "win_rate": 0.5
+        "win_rate": 0.75
     },
     {
         "_comment": "cp505@1600",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
         "max_visits_victim": 1600,
-        "win_rate": 0.5
+        "win_rate": 0.75
     }
 ]

--- a/configs/curriculum.json
+++ b/configs/curriculum.json
@@ -99,9 +99,63 @@
         "win_rate": 0.75
     },
     {
-        "_comment": "cp505@1600",
+        "_comment": "cp505@2048",
         "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
-        "max_visits_victim": 1600,
+        "max_visits_victim": 2048,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@4096",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 4096,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@8192",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 8192,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@16384",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 16384,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@32768",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 32768,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@65536",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 65536,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@131072",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 131072,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@262144",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 262144,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@524288",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 524288,
+        "win_rate": 0.75
+    },
+    {
+        "_comment": "cp505@1048576",
+        "name": "kata1-b40c256-s11840935168-d2898845681.bin.gz",
+        "max_visits_victim": 1048576,
         "win_rate": 0.75
     }
 ]


### PR DESCRIPTION
Changes:
* Increase win rate threshold from 0.5 to 0.75
  * Tony suggested this change a while ago so that we can't get an adversary that only wins as one color. It also means we spend marginally more time training on weaker adversaries than require less compute to evaluate.
* Change last checkpoint to be cp505-v1048576 instead of just cp505-v1600