### PR TITLE
baseline_attack: Allow Komi to be specified

### DIFF
--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -82,6 +82,7 @@ services:
         && python3 -u /go_attack/scripts/baseline_attack.py
         --engine ${VICTIM}
         --executable /connect-to-victim.sh
+        --komi ${KOMI}
         --log-dir /outputs/sgfs
         --num-games ${NUM_GAMES}
         --verbose

--- a/compose/transfer/launch.sh
+++ b/compose/transfer/launch.sh
@@ -29,7 +29,6 @@ function usage() {
   echo "  -k KOMI, --komi KOMI"
   echo "              The komi of the games."
   echo "              ELF only accepts a komi of 7.5."
-  echo "              Only used by katago-vs-* experiments."
   echo "              default: 6.5 vs. Leela, 7.5 vs. ELF"
   echo "  --katago-config CONFIG"
   echo "              Config for KataGo to use."
@@ -130,7 +129,7 @@ if [[ -z "${KOMI}" ]]; then
   KOMI=6.5
   [[ "${VICTIM}" == "elf" ]] && KOMI=7.5
 fi
-if [[ "${EXPERIMENT_NAME}" = katago-vs-elf ]] && [[ $KOMI != "7.5" ]]; then
+if [[ "${VICTIM}" = "elf" ]] && [[ $KOMI != "7.5" ]]; then
   echo "Warning: ELF only allows KOMI=7.5. Setting KOMI=7.5."
   KOMI=7.5
 fi

--- a/scripts/baseline_attack.py
+++ b/scripts/baseline_attack.py
@@ -109,8 +109,8 @@ def main():  # noqa: D103
     )
     args = parser.parse_args()
     if args.engine == "katago":
-        if args.num_playouts is None:
-            args.num_playouts = [512]
+        if args.num_visits is None:
+            args.num_visits = [512]
         if args.passing_behavior is None:
             args.passing_behavior = ["standard"]
 

--- a/scripts/baseline_attack.py
+++ b/scripts/baseline_attack.py
@@ -33,6 +33,7 @@ def main():  # noqa: D103
         default="katago",
         help="The type of engine that the victim is running on",
     )
+    parser.add_argument("--komi", type=float, default=6.5, help="Komi")
     # Because ELF OpenGo disallows suicide moves and we want to launch
     # consistent attacks across all engines, we default to disallowing suicide
     # moves.
@@ -166,6 +167,7 @@ def main():  # noqa: D103
         config_path=config_path,
         engine_type=args.engine,
         executable_path=executable_path,
+        komi=args.komi,
         log_analysis=args.log_analysis,
         log_root=args.log_dir,
         moves_before_pass=args.moves_before_pass,

--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -256,6 +256,7 @@ def run_baseline_attack(
     config_path: Path,
     engine_type: str,
     executable_path: Path,
+    komi: float = 6.5,
     log_analysis: bool = False,
     log_root: Optional[Path] = None,
     moves_before_pass: int = 211,
@@ -311,6 +312,7 @@ def run_baseline_attack(
         return PassingWrapper(policy, moves_before_pass)
 
     send_msg(to_engine, f"boardsize {board_size}")
+    send_msg(to_engine, f"komi {komi}")
 
     random.seed(seed)
     policy_cls = POLICIES[adversarial_policy]
@@ -325,7 +327,7 @@ def run_baseline_attack(
         if verbose:
             print(f"\n--- Game {i + 1} of {num_games} ---")
 
-        game = Game(board_size=board_size)
+        game = Game(board_size=board_size, komi=komi)
         policy = make_policy()
         game, analyses = rollout_policy(
             game,


### PR DESCRIPTION
## Description
For consistency we probably want to run our baseline attacks against KataGo with komi set to 6.5 rather than the default of 7.5. This PR makes komi configurable in `scripts/baseline_attack.py` via a flag.

## Testing

* launched baseline attack against KataGo and checked that custom komi is saved in the SGFs
* launched baseline attack against Leela with a komi of 999 and checks that at the end of the game, Leela outputs that White wins by a huge margin