### PR TITLE
baseline_attack: Quit KataGo after finishing

### DIFF
--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -357,6 +357,7 @@ def run_baseline_attack(
             analysis_log_dir.mkdir(exist_ok=True, parents=True)
             with open(analysis_log_dir / f"game_{i}.txt", "w") as f:
                 f.write("\n\n".join(analyses))
+    send_msg(to_engine, "quit")
 
     scores = [game.score() for game in games]
     margins = [black - white for black, white in scores]


### PR DESCRIPTION
When running multiple KataGo configs in parallel in `scripts/baseline_attack.py`, we should quit KataGo at the end of each run. Otherwise the KataGo process is leaked and takes up GPU memory until all runs are finished and `scripts/baseline_attack.py` terminates.