### PR TITLE
configs: Fix komis being swapped for small board sizes

### DIFF
--- a/configs/emcts1/components/board-sizes.cfg
+++ b/configs/emcts1/components/board-sizes.cfg
@@ -1,7 +1,7 @@
 # Which board sizes we play on.
 
-bSizes = 7,9,11,13,15,17,19,  8,10,12,14,16,18
-bSizeRelProbs = 1,4,3,10,7,9,35, 1,2,4,6,8,10
+bSizes = 7,8,9,10,11,12,13,14,15,16,17,18,19
+bSizeRelProbs = 1,1,4,2,3,4,10,6,7,8,9,10,35
 allowRectangleProb = 0.00
 
 maxMovesPerGame = 1600


### PR DESCRIPTION
Bug: `board-sizes.cfg` lists board sizes first grouped by odd board lengths and by even board length, whereas `komi-handicap.cfg`'s `komiByBSize` does not list komis grouped by odd/even lengths. The result is that we're accidentally setting komi=9.5 instead of 6.5 for 9x9 boards and komi=6.5 instead 9.5 for 8x8 boards.

Fix: reorder board sizes in `board-sizes.cfg`.