### PR TITLE
baseline_attack: Label PB[] and PW[] with adversary and victim

### DIFF
--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -343,9 +343,16 @@ def run_baseline_attack(
 
         # Save the game to disk if necessary
         if log_dir:
-            strat_title = adversarial_policy.capitalize()
-            victim_name = "Black" if victim == "B" else "White"
-            sgf = game.to_sgf(f"{strat_title} attack; {victim_name} victim")
+            adv_name = f"adv-baseline-{adversarial_policy}"
+            victim_name = "victim"
+            sgf = game.to_sgf(
+                comment=(
+                    f"{adversarial_policy.capitalize()} attack; "
+                    f"{'Black' if victim == 'B' else 'White'} victim"
+                ),
+                black_name=(victim_name if victim == "B" else adv_name),
+                white_name=(adv_name if victim == "B" else victim_name),
+            )
 
             with open(log_dir / f"game_{i}.sgf", "w") as f:
                 f.write(sgf)

--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -351,7 +351,7 @@ def run_baseline_attack(
                     f"{'Black' if victim == 'B' else 'White'} victim"
                 ),
                 black_name=(victim_name if victim == "B" else adv_name),
-                white_name=(adv_name if victim == "B" else victim_name),
+                white_name=(victim_name if victim == "W" else adv_name),
             )
 
             with open(log_dir / f"game_{i}.sgf", "w") as f:


### PR DESCRIPTION
* In SGFs generated by `baseline_attack.py`, label `PB[]` and `PW[]` with the adversarial policy and victim for easier parsing.

Example output SGF (edge attack vs. /dev/null):
```
(;FF[4]SZ[7]RU[NZ]KM[6.5]PB[victim]PW[adv-baseline-edge]C[Edge attack; Black victim]RE[W+6.5]
;B[fe];W[ag];B[be];W[bg];B[fb];W[gb];B[gg];W[gf];B[ea];W[aa];B[df];W[ca];B[ff];W[gc];B[ec];W[ae];B[cc];W[dg];B[];W[])
```