### PR TITLE
compose/transfer/launch.sh: Fix small usability issues

### DIFF
--- a/compose/transfer/launch.sh
+++ b/compose/transfer/launch.sh
@@ -194,9 +194,6 @@ if [[ "${VICTIM}" == "leela" ]]; then
   touch -a "${HOST_LEELA_TUNING_FILE}"
 fi
 
-echo "Pruning Docker networks because this script will use a lot of networks:"
-docker network prune
-
 # shellcheck disable=SC2154
 trap 'exit_code=$?; free_resources; exit $exit_code' INT TERM
 


### PR DESCRIPTION
Fixes to launch script for transfer experiments:
* Parse flags until we see a non-flag, not until the last two arguments (otherwise we won't correctly print a usage message if we run with the arguments `-h foobar`)
* Clean up Docker networks even if the job is interrupted
* Build images before launching (otherwise every launched game may in parallel attempt to build the same Docker images simultaneously)
* `shellcheck` linting