### PR TITLE
configs: Make match config use GTP temperatures

### DIFF
--- a/configs/match.cfg
+++ b/configs/match.cfg
@@ -31,3 +31,7 @@ bSizeRelProbs = 1
 
 # Example match default is 10^6
 numGamesTotal = 1000
+
+# These temperature values are the values used by GTP.
+chosenMoveTemperature = 0.10
+chosenMoveTemperatureEarly = 0.50


### PR DESCRIPTION
Changes:
* Make `match.cfg` config closer to `gtp-base.cfg` config by making match's temperature parameters match GTP's. (`gtp-base.cfg` does not specify the temperature parameters, which gives the default values `chosenMoveTemperature = 0.20, chosenMoveTemperatureEarly = 0.60`.)

Discussion on why we should make the match config closer to the GTP config: https://farinc.slack.com/archives/C01R2R7NH2P/p1672118741210689

For reference, gtp-base.cfg is
```
allowResignation = false
cudaUseNHWC = true
deviceToUseThread0 = 0
deviceToUseThread1 = 0
deviceToUseThread2 = 0
deviceToUseThread3 = 0
koRule = POSITIONAL
lagBuffer = 1.0
logAllGTPCommunication = false
logSearchInfo = false
maxTimePondering = 60
multiStoneSuicideLegal = false
nnCacheSizePowerOfTwo = 24
nnMaxBatchSize = 256
nnMutexPoolSizePowerOfTwo = 18
nnRandomize = true
numGameThreads = 200
numNNServerThreadsPerModel = 4
numSearchThreads = 1
ponderingEnabled = false
resignConsecTurns = 3
resignThreshold = -0.90
scoringRule = AREA
useFP16 = true
```
The diff between `gtp-base.cfg` and `match-1gpu.cfg`:
```diff
1a2,8
> bSizeRelProbs = 1
> bSizes = 19
> botName = FOO
> botName0 = victim
> botName1 = adversary
> chosenMoveTemperature = 0.20
> chosenMoveTemperatureEarly = 0.60
7,9c14,24
< koRule = POSITIONAL
< lagBuffer = 1.0
< logAllGTPCommunication = false
---
> handicapCompensateKomiProb = 1.0
> handicapProb = 0.0
> hasButtons = false
> koRules = POSITIONAL
> komiAuto = false
> komiBigStdev = 0
> komiBigStdevProb = 0
> komiMean = 6.5
> komiStdev = 0
> logGamesEvery = 50
> logMoves = false
11,15c26,35
< maxTimePondering = 60
< multiStoneSuicideLegal = false
< nnCacheSizePowerOfTwo = 24
< nnMaxBatchSize = 256
< nnMutexPoolSizePowerOfTwo = 18
---
> logToStdout = true
> maxMovesPerGame = 1200
> maxVisits = 500
> maxVisits0 = 1
> maxVisits1 = 200
> multiStoneSuicideLegals = true
> nnCacheSizePowerOfTwo = 21
> nnMaxBatchSize = 32
> nnModelFile = /dev/null
> nnMutexPoolSizePowerOfTwo = 17
17,18c37,40
< numGameThreads = 200
< numNNServerThreadsPerModel = 4
---
> numBots = 2
> numGameThreads = 8
> numGamesTotal = 1000
> numNNServerThreadsPerModel = 1
20,23c42,47
< ponderingEnabled = false
< resignConsecTurns = 3
< resignThreshold = -0.90
< scoringRule = AREA
---
> resignConsecTurns = 6
> resignThreshold = -0.95
> scoringRules = AREA
> searchAlgorithm0 = MCTS
> searchAlgorithm1 = AMCTS
> taxRules = NONE
```

