### PR TITLE
[DO NOT MERGE] transfer: Modify transfer setup to allow resuming games against cp505-v10mil

### DIFF
--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -149,6 +149,20 @@ services:
         2>&1 | tee --append /outputs/katago-raw.log
       "
 
+  katago-custom:
+    <<: *katago
+    profiles:
+      - katago-custom
+    command: >
+      sh -c "
+        socat TCP4-LISTEN:80,reuseaddr \
+        EXEC:\"/engines/KataGo-custom/cpp/katago gtp \
+          -config ${HOST_REPO_ROOT}/configs/gtp-custom.cfg \
+          -model /victim-model/${KATAGO_VICTIM_MODEL} \
+          \" \
+        2>&1 | tee --append /outputs/katago-custom.log
+      "
+
   twogtp:
     profiles:
       - katago
@@ -163,12 +177,16 @@ services:
       - type: bind
         source: ${HOST_OUTPUT_DIR}
         target: /outputs
+      - type: bind
+        source: ${OPENINGS}
+        target: /openings
     command:
       sh -c "
         mkdir --parents /outputs/sgfs &&
         bin/gogui-twogtp
-          -black 'nc ${VICTIM} 80' -white 'nc katago 80'
+          -${KATAGO_VICTIM_COLOR} 'nc ${VICTIM} 80' -${KATAGO_ADV_COLOR} 'nc katago 80'
           -alternate -auto -games ${NUM_GAMES} -komi ${KOMI} -maxmoves 1600
+          -openings /openings
           -sgffile /outputs/sgfs/game -verbose
         2>&1 | tee --append /outputs/twogtp.log
       "

--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -5,10 +5,11 @@
 # reverse convention. TODO: should we change this?
 numBots = 2
 
-maxVisits0 = 200
+maxVisits = 600
+maxVisits0 = 600
 searchAlgorithm0 = AMCTS
 
-maxVisits1 = 32
+maxVisits1 = 1
 searchAlgorithm1 = MCTS
 
 # This is set to 6 in the original gtp_example.cfg but A-MCTS only supports numSearchThreads = 1

--- a/configs/gtp-base.cfg
+++ b/configs/gtp-base.cfg
@@ -1,7 +1,6 @@
 @include compute/1gpu.cfg
 
 # We're not really interested in detailed logging when running with GTP
-logSearchInfo = false
 logAllGTPCommunication = false
 
 # Remove unnecessary non-determinism
@@ -11,11 +10,7 @@ numSearchThreads = 1
 # means we also need to set the other rules instead of relying on rules = tromp-taylor
 koRule = POSITIONAL
 scoringRule = AREA
-multiStoneSuicideLegal = false
-
-allowResignation = false
-resignConsecTurns = 3
-resignThreshold = -0.90
+# multiStoneSuicideLegal = false
 
 # The below parameters are copied from gtp_example.cfg; we need to copy instead of @include because
 # it's currently impossible to override "rules = tromp-taylor" once it's set in an included file.
@@ -29,3 +24,23 @@ ponderingEnabled = false
 # searchFactorAfterTwoPass = 0.25
 # searchFactorWhenWinning = 0.40
 # searchFactorWhenWinningThreshold = 0.95
+
+# ---
+# Parameters from match against cp505-v10mil
+
+allowResignation = true
+chosenMoveTemperature = 0.20
+chosenMoveTemperatureEarly = 0.60
+cudaUseNHWC = true
+hasButton = false
+logSearchInfo = true
+logToStdout = true
+multiStoneSuicideLegal = true
+nnCacheSizePowerOfTwo = 24
+nnMaxBatchSize = 256
+nnMutexPoolSizePowerOfTwo = 18
+nnRandomize = true
+resignConsecTurns = 6
+resignThreshold = -0.95
+taxRule = NONE
+useFP16 = true

--- a/configs/gtp-custom.cfg
+++ b/configs/gtp-custom.cfg
@@ -1,0 +1,6 @@
+@include gtp-base.cfg
+
+numBots = 1
+maxVisits = 10000000
+numSearchThreads = 40
+searchAlgorithm = MCTS


### PR DESCRIPTION
We have a few `match` games of an adversary vs. cp505-v10mil that got killed early. From looking at logs, we can reconstruct SGFs for the games and resume the games using our transfer experiment setup. 

The strategy:
* gogui's `twogtp` command has a [`-openings` flag](https://www.kayufu.com/gogui/reference-twogtp.html). If we give `-openings` a directory with only 1 SGF, then `twogtp` will initialize the game between two bots with the moves from that SGF.
* Now we just use our transfer setup to play two instances of KataGo against each other. (Perhaps there are subtle differences between GTP and match behavior, so I'm not confident that this is _exactly_ resuming the `match` games. But hopefully it's close enough to still give meaningful results.)

Example launch command:
```
./compose/transfer/launch.sh \
  --gpus 2 \
  --katago-model /nas/ucb/k8/go-attack/victimplay/ttseng-avoid-pass-alive-coldstart-39-20221025-175949/models/t0-s545065216-d136760487/model.bin.gz  \
  --katago-victim-model /nas/ucb/ttseng/go_attack/models/victim/cp505.bin.gz \
  --katago-adv-color black \
  --openings /nas/ucb/ttseng/go_attack/misc/10mil-unfinished-games/sgfs/game0 \
  --label v10mil-game0 \
  --num-games 1 \
  --num-threads 1 \
  katago-vs-katago-custom up
```

I am not merging this PR because I wrote this feature rather quickly and it does some undesirable stuff (e.g., right now `--openings` is _required_ for `./compose/transfer/launch.sh`, which is definitely not what we want in general) — I'd want to clean it up more before merging. I'm not sure we'll ever need this functionality again so for now we can just close this PR as a one-off feature.