### PR TITLE
configs: Update match config to be closer to GTP defaults

### DIFF
--- a/configs/match.cfg
+++ b/configs/match.cfg
@@ -32,6 +32,15 @@ bSizeRelProbs = 1
 # Example match default is 10^6
 numGamesTotal = 1000
 
-# These temperature values are the values used by GTP.
+# These parameter values are copied from GTP---default GTP settings are
+# considered the canonical settings.
 chosenMoveTemperature = 0.10
 chosenMoveTemperatureEarly = 0.50
+rootSymmetryPruning = true
+antiMirror = true
+fillDameBeforePass = true
+# TODO(tomtseng): conservativePass  has a bug that sometimes makes the bot weaker
+# to passing-based attacks. We should merge commits up to
+# https://github.com/lightvector/KataGo/commit/eea5d0cbc3909ef55b81b364b19593d83f7aefa8
+# (Jan 11, 2023) into KataGo-custom before setting conservativePass to true.
+# conservativePass = true


### PR DESCRIPTION
The config settings are set to true by GTP by default, so let's set them to be true in `match.cfg` too.
```
rootSymmetryPruning = true
antiMirror = true
fillDameBeforePass = true
# we shouldn't actually enable conservativePass yet---we should merge
# a recent bugfix from KataGo-raw into KataGo-custom first
conservativePass = true 
```