### PR TITLE
Adjust ELF/Leela parameters

### DIFF
--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -122,6 +122,7 @@ services:
         socat TCP4-LISTEN:80,reuseaddr \
         EXEC:\"/engines/KataGo-custom/cpp/katago gtp \
           -config ${KATAGO_CONFIG} \
+          -override-config logSearchInfo=true,logToStdout=true \
           -model /adversary-model/${KATAGO_MODEL} \
           -victim-model /victim-model/${KATAGO_VICTIM_MODEL} \
           \" \
@@ -144,6 +145,7 @@ services:
         socat TCP4-LISTEN:80,reuseaddr \
         EXEC:\"/engines/KataGo-raw/cpp/katago gtp \
           -config ${HOST_REPO_ROOT}/configs/gtp-raw.cfg \
+          -override-config logSearchInfo=true,logToStdout=true \
           -model /victim-model/${KATAGO_VICTIM_MODEL} \
           \" \
         2>&1 | tee --append /outputs/katago-raw.log

--- a/compose/transfer/compose.yml
+++ b/compose/transfer/compose.yml
@@ -122,7 +122,7 @@ services:
         socat TCP4-LISTEN:80,reuseaddr \
         EXEC:\"/engines/KataGo-custom/cpp/katago gtp \
           -config ${KATAGO_CONFIG} \
-          -override-config logSearchInfo=true,logToStdout=true \
+          -override-config logSearchInfo=true\,logToStdout=true \
           -model /adversary-model/${KATAGO_MODEL} \
           -victim-model /victim-model/${KATAGO_VICTIM_MODEL} \
           \" \
@@ -145,7 +145,7 @@ services:
         socat TCP4-LISTEN:80,reuseaddr \
         EXEC:\"/engines/KataGo-raw/cpp/katago gtp \
           -config ${HOST_REPO_ROOT}/configs/gtp-raw.cfg \
-          -override-config logSearchInfo=true,logToStdout=true \
+          -override-config logSearchInfo=true\,logToStdout=true \
           -model /victim-model/${KATAGO_VICTIM_MODEL} \
           \" \
         2>&1 | tee --append /outputs/katago-raw.log

--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -5,7 +5,7 @@
 # reverse convention. TODO: should we change this?
 numBots = 2
 
-maxVisits0 = 200
+maxVisits0 = 600
 searchAlgorithm0 = AMCTS
 
 maxVisits1 = 32

--- a/engines/elf/run-gtp.sh
+++ b/engines/elf/run-gtp.sh
@@ -21,8 +21,15 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # Parameters for ELF OpenGo. If FAST is not set, then we're running ELF with
-# the default parameters listed in the ELF README, except that `--resign_thres`
-# is set to 0 instead of 0.05.
+# the default parameters listed in the ELF README, except for the following
+# changes:
+# - `--resign_thres` is set to 0 instead of 0.05.
+# - `--mcts_rollout_per_thread` is set to 40,000 (for a total of 80,000
+#   rollouts) instead of 8,192 to make ELF play at a superhuman level.
+#   - The ELF paper says that ELF running with the "prototype model" with
+#     ~80,000 playouts won 20/20 games in total against four top-30 players.
+#     We're using the "final model", which is 150 Elo stronger than the
+#     prototype model.
 FLAGS="\
   --gpu 0 \
   --num_block 20 \
@@ -43,7 +50,7 @@ else
     --batchsize 16 \
     --mcts_rollout_per_batch 16 \
     --mcts_threads 2 \
-    --mcts_rollout_per_thread 8192 \
+    --mcts_rollout_per_thread 40000 \
   "
 fi
 if [[ -n "${VERBOSE}" ]]; then

--- a/engines/leela/Dockerfile
+++ b/engines/leela/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update --quiet \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN git clone --depth=1 --branch=v0.0.0 --recurse-submodules \
+RUN git clone --depth=1 --branch=v0.0.1 --recurse-submodules \
   --shallow-submodules https://github.com/HumanCompatibleAI/leela-zero
 WORKDIR leela-zero/build
 RUN cmake .. && cmake --build . -- -j16

--- a/engines/leela/run-gtp.sh
+++ b/engines/leela/run-gtp.sh
@@ -20,12 +20,19 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
-FLAGS="--noponder"
+FLAGS="--noponder --resignpct 0"
 if [[ -n "${FAST}" ]]; then
   FLAGS+="\
     --playouts 1 \
     --timemanage fast \
     --visits 1 \
+  "
+else
+  # It's not documented at what settings Leela plays at a superhuman
+  # level. We'll guess that 32k visits is sufficient.
+  FLAGS+="\
+    --timelimit 0 \
+    --visits 32768 \
   "
 fi
 if [[ -z "${VERBOSE}" ]]; then

--- a/engines/leela/run-gtp.sh
+++ b/engines/leela/run-gtp.sh
@@ -29,10 +29,10 @@ if [[ -n "${FAST}" ]]; then
   "
 else
   # It's not documented at what settings Leela plays at a superhuman
-  # level. We'll guess that 32k visits is sufficient.
+  # level. We'll guess that 40k visits is sufficient.
   FLAGS+="\
     --timelimit 0 \
-    --visits 32768 \
+    --visits 40000 \
   "
 fi
 if [[ -z "${VERBOSE}" ]]; then


### PR DESCRIPTION
ELF changes:
* Increase number of playouts from 16,384 to 80,000, since this is the level at which we expect ELF to be superhuman or nearly superhuman based on the ELF paper

Leela changes:
* Turn off Leela resignation (`--resignpct 0`), to be consistent with us turning off KataGo and ELF resignation
* Turn off Leela time limit and instead impose a max visit count of 40000
  * Why: Leela defaults to playing with a 1 hour time limit (~30 seconds per move), but depending on time limits will lead to inconsistent results on different hardware
  * Turning off the time limit required minor code changes in our fork of Leela: https://github.com/HumanCompatibleAI/leela-zero/pull/1

These parameters were used in the latest transfer experiments (https://www.notion.so/chaiberkeley/transfer-adv-545-0mil-v600-vs-leela-ELF-d0b67ef76ec94e17ab697ca97399fa91).

Our Elo analysis predicts cp505-v128 is superhuman. ELF with these parameters beats cp505-v128 in 7/10 games, and Leela with these parmaeters beats cp505-v128 in 18/32 games (https://www.notion.so/chaiberkeley/cp505-v128-vs-ELF-Leela-93c2b8bde9264de1b1dfa52fbb5a8951).